### PR TITLE
Replaced LocalDate.compareTo with ChronoUnit for day difference calculation

### DIFF
--- a/hotel-booking-app-service/src/main/java/com/application/hotelbooking/services/implementations/ReservationServiceImpl.java
+++ b/hotel-booking-app-service/src/main/java/com/application/hotelbooking/services/implementations/ReservationServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -67,7 +68,7 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     public int calculateTotalPrice(LocalDate startDate, LocalDate endDate, int pricePerNight){
-        return pricePerNight * endDate.compareTo(startDate);
+        return pricePerNight * (int) ChronoUnit.DAYS.between(startDate, endDate);
     }
 
     public ReservationModel prepareReservation(ReservableRoomDTO reservableRoomDTO, String userName){


### PR DESCRIPTION
LocalDate.compareTo() is not intended for calculating difference between LocalDates. Instead it should be used to check if a date is before, after or same as the other. 
So far it was only a coincidence that it returned the correct difference for the date. But calling it on two dates in different months clearly gives incorrect results.

To properly calculate the date difference in days, I replaced it with ChronoUnit.DAYS.between(), which is intended for this exact task.

https://docs.oracle.com/javase/8/docs/api/java/time/LocalDate.html#compareTo-java.time.chrono.ChronoLocalDate-
https://stackoverflow.com/a/70985947
