### PR TITLE
Update cancel reservation logic

### DIFF
--- a/hotel-booking-app-service/src/main/java/com/application/hotelbooking/exceptions/InvalidReservationException.java
+++ b/hotel-booking-app-service/src/main/java/com/application/hotelbooking/exceptions/InvalidReservationException.java
@@ -1,0 +1,8 @@
+package com.application.hotelbooking.exceptions;
+
+public class InvalidReservationException extends RuntimeException {
+    public InvalidReservationException(String message) {
+        super(message);
+    }
+
+}

--- a/hotel-booking-app-service/src/main/java/com/application/hotelbooking/services/ReservationService.java
+++ b/hotel-booking-app-service/src/main/java/com/application/hotelbooking/services/ReservationService.java
@@ -4,14 +4,18 @@ import com.application.hotelbooking.domain.ReservationModel;
 import com.application.hotelbooking.domain.RoomModel;
 import com.application.hotelbooking.dto.HotelWithReservableRoomsServiceDTO;
 import com.application.hotelbooking.dto.ReservationPlanServiceDTO;
+import com.application.hotelbooking.exceptions.InvalidReservationException;
+import com.application.hotelbooking.exceptions.InvalidTokenException;
+import com.application.hotelbooking.exceptions.InvalidUserException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 public interface ReservationService {
     List<ReservationModel> getReservationsOfUser(String username);
-    void cancelReservation(Long reservationId);
+    void cancelReservation(UUID uuid, String userName) throws InvalidTokenException, InvalidReservationException, InvalidUserException;
     int calculateTotalPrice(LocalDate startDate, LocalDate endDate, int pricePerNight);
     ReservationPlanServiceDTO createReservationPlan(int roomNumber, String hotelName, List<HotelWithReservableRoomsServiceDTO> hotelWithReservableRoomsServiceDTOS);
     ReservationModel prepareReservation(ReservationPlanServiceDTO reservationPlanServiceDTO, RoomModel roomModel, String userName);

--- a/hotel-booking-app-web/src/main/java/com/application/hotelbooking/controllers/MyReservationsController.java
+++ b/hotel-booking-app-web/src/main/java/com/application/hotelbooking/controllers/MyReservationsController.java
@@ -1,6 +1,9 @@
 package com.application.hotelbooking.controllers;
 
 import com.application.hotelbooking.domain.ReservationView;
+import com.application.hotelbooking.exceptions.InvalidReservationException;
+import com.application.hotelbooking.exceptions.InvalidTokenException;
+import com.application.hotelbooking.exceptions.InvalidUserException;
 import com.application.hotelbooking.services.ReservationService;
 import com.application.hotelbooking.transformers.ReservationViewTransformer;
 import org.slf4j.Logger;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
+import java.util.UUID;
 
 @Controller
 @RequestMapping(path = "hotelbooking/my-reservations")
@@ -29,9 +33,18 @@ public class MyReservationsController {
     private ReservationViewTransformer reservationViewTransformer;
 
     @PostMapping(value = "/cancel-reservation")
-    public String cancelReservation(@ModelAttribute("reservationId") Long reservationId){
+    public String cancelReservation(@ModelAttribute("reservationUuid") UUID uuid, Authentication auth){
         try {
-            reservationService.cancelReservation(reservationId);
+            reservationService.cancelReservation(uuid, auth.getName());
+        } catch (InvalidTokenException ite) {
+            LOGGER.info(ite.getMessage());
+            return "redirect:/hotelbooking/my-reservations?error";
+        } catch (InvalidReservationException ire) {
+            LOGGER.info(ire.getMessage());
+            return "redirect:/hotelbooking/my-reservations?error";
+        } catch (InvalidUserException iue) {
+            LOGGER.info(iue.getMessage());
+            return "redirect:/hotelbooking/my-reservations?error";
         } catch (Exception e) {
             LOGGER.info(e.getMessage());
             return "redirect:/hotelbooking/my-reservations?error";

--- a/hotel-booking-app-web/src/main/java/com/application/hotelbooking/dto/NewUserFormDTO.java
+++ b/hotel-booking-app-web/src/main/java/com/application/hotelbooking/dto/NewUserFormDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class NewUserFormDTO {
-    @Size(min = 8, max = 18, message = "{registration.error.username.length}")
+    @Size(min = 4, max = 18, message = "{registration.error.username.length}")
     private String username;
     @Size(min = 8, max = 18, message = "{registration.error.password.length}")
     private String password;

--- a/hotel-booking-app-web/src/main/resources/templates/myreservations.html
+++ b/hotel-booking-app-web/src/main/resources/templates/myreservations.html
@@ -59,7 +59,7 @@
                 <td th:insert="~{fragments/reservationstatusnames ::reservationstatusnames(${reservation.reservationStatus})}" hidden="true"></td>
                 <td>
                     <form th:if="${#strings.equals(reservation.reservationStatus.toString(), 'PLANNED')}" th:action="@{/hotelbooking/my-reservations/cancel-reservation}" method="post">
-                        <button class="btn btn-danger" th:value="${reservation.id}" th:name="reservationId" th:text="#{myreservations.button.cancel}" />
+                        <button class="btn btn-danger" th:value="${reservation.uuid}" th:name="reservationUuid" th:text="#{myreservations.button.cancel}" />
                     </form>
                     <form th:if="${#strings.equals(reservation.reservationStatus.toString(), 'COMPLETED')}" th:action="@{/hotelbooking/review}" method="get">
                         <button class="btn btn-primary" th:value="${reservation.uuid}" th:name="reservationUuid" th:text="#{myreservations.button.leave.review}" />

--- a/hotel-booking-app-web/src/test/java/com/application/hotelbooking/controllers/MyReservationsControllerTest.java
+++ b/hotel-booking-app-web/src/test/java/com/application/hotelbooking/controllers/MyReservationsControllerTest.java
@@ -1,6 +1,9 @@
 package com.application.hotelbooking.controllers;
 
 import com.application.hotelbooking.domain.*;
+import com.application.hotelbooking.exceptions.InvalidReservationException;
+import com.application.hotelbooking.exceptions.InvalidTokenException;
+import com.application.hotelbooking.exceptions.InvalidUserException;
 import com.application.hotelbooking.security.SecurityConfiguration;
 import com.application.hotelbooking.services.ReservationService;
 import com.application.hotelbooking.transformers.ReservationViewTransformer;
@@ -16,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -27,6 +31,7 @@ public class MyReservationsControllerTest {
 
     private static final Long RESERVATION_ID = 1L;
     private static final String TEST_USER_NAME = "test_user";
+    private static final UUID TEST_UUID = UUID.fromString("2a167ea9-850c-4059-8163-6f941561c419");
     private static final LocalDate START_DATE = LocalDate.of(2024, 3, 1);
     private static final LocalDate END_DATE = LocalDate.of(2024, 3, 2);
     private static final ReservationModel RESERVATION_MODEL = ReservationModel.builder().reservationStatus(ReservationStatus.PLANNED).build();
@@ -89,26 +94,50 @@ public class MyReservationsControllerTest {
     }
 
     @Test
-    @WithMockUser(authorities = "USER")
-    public void testCancelReservationShouldRedirectToMyReservationsPageWithGenericErrorIfCancelReservationThrowsAnyException() throws Exception {
-        doThrow(DataIntegrityViolationException.class).when(reservationService).cancelReservation(RESERVATION_ID);
+    @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
+    public void testCancelReservationShouldRedirectToMyReservationsPageWithGenericErrorIfCancelReservationThrowsInvalidTokenException() throws Exception {
+        doThrow(InvalidTokenException.class).when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/hotelbooking/my-reservations/cancel-reservation")
-                        .flashAttr("reservationId", RESERVATION_ID))
+                        .flashAttr("reservationUuid", TEST_UUID))
                 .andExpect(redirectedUrl("/hotelbooking/my-reservations?error"));
 
-        verify(reservationService).cancelReservation(RESERVATION_ID);
+        verify(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
     }
 
     @Test
-    @WithMockUser(authorities = "USER")
-    public void testCancelReservationShouldRedirectToMyReservationsPageIfNoExceptionOccurredWhileCancellingReservation() throws Exception {
-        doNothing().when(reservationService).cancelReservation(RESERVATION_ID);
+    @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
+    public void testCancelReservationShouldRedirectToMyReservationsPageWithGenericErrorIfCancelReservationThrowsInvalidReservationException() throws Exception {
+        doThrow(InvalidReservationException.class).when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/hotelbooking/my-reservations/cancel-reservation")
-                        .flashAttr("reservationId", RESERVATION_ID))
+                        .flashAttr("reservationUuid", TEST_UUID))
+                .andExpect(redirectedUrl("/hotelbooking/my-reservations?error"));
+
+        verify(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+    }
+
+    @Test
+    @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
+    public void testCancelReservationShouldRedirectToMyReservationsPageWithGenericErrorIfCancelReservationThrowsInvalidUserException() throws Exception {
+        doThrow(InvalidUserException.class).when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/hotelbooking/my-reservations/cancel-reservation")
+                        .flashAttr("reservationUuid", TEST_UUID))
+                .andExpect(redirectedUrl("/hotelbooking/my-reservations?error"));
+
+        verify(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+    }
+
+    @Test
+    @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
+    public void testCancelReservationShouldRedirectToMyReservationsPageIfNoExceptionOccurredWhileCancellingReservation() throws Exception {
+        doNothing().when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/hotelbooking/my-reservations/cancel-reservation")
+                        .flashAttr("reservationUuid", TEST_UUID))
                 .andExpect(redirectedUrl("/hotelbooking/my-reservations"));
 
-        verify(reservationService).cancelReservation(RESERVATION_ID);
+        verify(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
     }
 }

--- a/hotel-booking-app-web/src/test/java/com/application/hotelbooking/controllers/MyReservationsControllerTest.java
+++ b/hotel-booking-app-web/src/test/java/com/application/hotelbooking/controllers/MyReservationsControllerTest.java
@@ -131,6 +131,19 @@ public class MyReservationsControllerTest {
 
     @Test
     @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
+    public void testCancelReservationShouldRedirectToMyReservationsPageWithGenericErrorIfCancelReservationThrowsAnyException() throws Exception {
+        doThrow(DataIntegrityViolationException.class).when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/hotelbooking/my-reservations/cancel-reservation")
+                        .flashAttr("reservationUuid", TEST_UUID))
+                .andExpect(redirectedUrl("/hotelbooking/my-reservations?error"));
+
+        verify(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
+    }
+
+
+    @Test
+    @WithMockUser(authorities = "USER", username = TEST_USER_NAME)
     public void testCancelReservationShouldRedirectToMyReservationsPageIfNoExceptionOccurredWhileCancellingReservation() throws Exception {
         doNothing().when(reservationService).cancelReservation(TEST_UUID, TEST_USER_NAME);
 


### PR DESCRIPTION
Previously when a user tried to cancel a reservation they only needed to be authenticated and provide the Id of the reservation entity. There were multiple issues with this approach:

-  exposed the id to the user, which should only belong to the database context
-  malicious users could alter the URL with any desired Id and it would be deleted without any checking its owner
- unlike with reviews, there were no checks for reservation status, so even `ACTIVE` and `COMPLETED` reservations could be cancelled

As a solution first I switched the parameter of `"/cancel-reservation"` to use the UUID of the reservations instead. Then when the request is passed to the service I also provide the user as well. There it checks if the reservation exists, is it in `PLANNED` status, and does it belong to the user making the request. If all of these checks are passed then it is deleted the same way as before.
I have also updated the tests for these service and controller methods.