### PR TITLE
Quick fix for project version change issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN chmod +x copy_files.sh
 
 COPY data.sql .
 
-COPY --from=build /app/hotel-booking-app-web/target/hotel-booking-app-web-0.0.1-SNAPSHOT.jar hotel-booking-app.jar
+COPY --from=build /app/hotel-booking-app-web/target/*.jar hotel-booking-app.jar
 
 ENTRYPOINT ["java", "-jar", "hotel-booking-app.jar"]


### PR DESCRIPTION
In previous versions the `Dockerfile` copied the executable jar by it's exact name, which was `hotel-booking-app-web-0.0.1-SNAPSHOT.jar`. By raising the project version right before merging changes into `main`, the jar name also changed. But the `Dockerfile` did not follow these changes, which caused the docker build to fail.

As a solution I replaced the exact file name with a wildcard character matching any jar files in the target folder.